### PR TITLE
Add gocmod.com bypass

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -820,6 +820,13 @@ hrefBypass(myDramaListRegex, () => {
     safelyNavigate(decodeURIComponent(document.URL.split(/\bmydramalist\.com\/redirect\?q=/)[1]))
 })
 //Insertion point for bypasses running before the DOM is loaded.
+domainBypass("gocmod.com", () => {
+    const url = new URL(window.location.href);
+    const actualLink = url.searchParams.get("urls");
+    if (actualLink) {
+        safelyNavigate(actualLink);
+    }
+})
 domainBypass("bstlar.com", () => {
     // boostellar bypass too easy
     const boostellar_link = encodeURIComponent(location.pathname.slice(1))


### PR DESCRIPTION
<!-- A link to all issues that this pull request will address, 
Link all issues with the number, like #123. Put "None" if you are making a new bypass-->
Fixes (Links to issues fixed by this PR): 
#1019
<!-- A brief description of what you did. Write the sites you bypassed and what changes/ additions to the source code.
Don't worry about this being too long, we care more about the code than your writing skills 😉-->
Description:
 Added functionality to bypass gocmod.com redirecting page. The script now attempts to capture the actual URL from the URL search parameters. If an actual link is found, it directly navigates to it, skipping the unnecessary redirection implemented by gocmod.com.
<!-- Add test links for all sites in the pull request. Make sure to link one test link per site
Make sure to hyperlink test links to avoid making the PR look messy
To make a hyperlink, the format is [domain name](direct link)-->
Test links:
 https://gocmod.com/myfitnesspal-subscribed-mod//file/?urls=https://www.mediafire.com/file/iw7541x8n1mfp39/MyFitnessPal-Premium-v23.11.5_build_29515-Mod.apk/file&names=MyFitnessPal%20Mod%20APK&sizes=85%20Mb
Checklist:
<!--Add an x to mark as done-->
- [x ] I made sure there are no unnecessary changes in the code*
- [x ] Tested on Chromium- Browser OS
- [x ] Tested on Firefox

<!--\* indicates required -->
